### PR TITLE
Setup railway deployment infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
+## STOMP Toy 01 – Railway Deployment Guide
 
+- **Stack**: Spring Boot (WebSocket), Maven wrapper, Java 21.
+- **Goal**: Containerize the app and prepare a repeatable Railway deployment workflow.
+- **Key Assets**: `stomp-toy-01/Dockerfile`, `stomp-toy-01/.dockerignore`.
+
+### Local Development
+
+- Install JDK 21+ and ensure `./stomp-toy-01/mvnw` is executable (`chmod +x mvnw` if needed).
+- Start the application locally:
+  - `cd stomp-toy-01`
+  - `./mvnw spring-boot:run`
+- Run tests anytime with `./mvnw test`.
+
+### Build and Run with Docker
+
+- Build the container image (from repository root):
+  - `docker build -t stomp-toy-01 ./stomp-toy-01`
+- Run the image locally:
+  - `docker run --rm -p 8080:8080 stomp-toy-01`
+- The container exposes port `8080`; Railway will automatically map traffic to the same port.
+
+### Deploying on Railway
+
+- Install the Railway CLI (`npm install -g @railway/cli` or use their install script).
+- Authenticate: `railway login`
+- Initialize the project (monorepo-aware):
+  - `railway init --service stomp-toy-01 --root ./stomp-toy-01`
+  - Accept or create a Railway project when prompted.
+- (Optional) Configure environment variables:
+  - `railway variables set SPRING_PROFILES_ACTIVE=prod`
+- Trigger a deployment:
+  - `railway up --service stomp-toy-01`
+- Railway detects the `Dockerfile`, builds the image remotely, and runs `java -jar app.jar`.
+
+### Continuous Deployment Tips
+
+- Subsequent pushes can be deployed by re-running `railway up`.
+- Use Railway environments (e.g., `railway environment create staging`) to isolate configs.
+- Monitor deploys and logs in the Railway dashboard or via `railway status` and `railway logs`.

--- a/stomp-toy-01/.dockerignore
+++ b/stomp-toy-01/.dockerignore
@@ -1,0 +1,9 @@
+target/
+.env
+.git
+.gitignore
+.idea/
+*.iml
+*.log
+node_modules/
+tmp/

--- a/stomp-toy-01/Dockerfile
+++ b/stomp-toy-01/Dockerfile
@@ -1,0 +1,22 @@
+FROM eclipse-temurin:21-jdk AS build
+WORKDIR /workspace/app
+
+# Install project dependencies first to leverage Docker layer caching
+COPY .mvn/ .mvn/
+COPY mvnw mvnw
+COPY pom.xml pom.xml
+RUN chmod +x mvnw
+RUN ./mvnw -B dependency:go-offline
+
+# Copy the rest of the source and build the application
+COPY src src
+RUN ./mvnw -B clean package -DskipTests
+
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+
+# Copy the fat jar produced by the Spring Boot build
+COPY --from=build /workspace/app/target/*.jar app.jar
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
Add Dockerfile, .dockerignore, and README instructions to enable Railway deployment for the Spring Boot service.

---
<a href="https://cursor.com/background-agent?bcId=bc-e2c063a3-9b1a-4264-bd6c-84982d74e1f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e2c063a3-9b1a-4264-bd6c-84982d74e1f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

