### PR TITLE
Configure railpack project type detection

### DIFF
--- a/.railpack.yml
+++ b/.railpack.yml
@@ -1,0 +1,1 @@
+project_path: stomp-toy-01


### PR DESCRIPTION
Add `.railpack.yml` to configure Railpack to correctly identify the project within the `stomp-toy-01` subdirectory.

---
<a href="https://cursor.com/background-agent?bcId=bc-d809fba9-ca9c-4299-a3c0-a123307da108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d809fba9-ca9c-4299-a3c0-a123307da108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

